### PR TITLE
Cleaned redundant aliases, fixed antigen source

### DIFF
--- a/deplist-common
+++ b/deplist-common
@@ -1,3 +1,2 @@
-curl -L git.io/antigen > ~/antigen.zsh
 curl -sLf https://raw.githubusercontent.com/NTBBloodbath/doom-nvim/main/install.sh | bash
 curl -fLo dotfiler.sh https://gitlab.com/Groctel/dotfiles-manager/-/raw/main/dotfiler.sh

--- a/files-common/.zshrc
+++ b/files-common/.zshrc
@@ -1,6 +1,6 @@
 # ANTIGEN SETTINGS
 
-source ~/.antigen.zsh
+source /usr/share/zsh/share/antigen.zsh
 
 antigen use oh-my-zsh
 
@@ -41,14 +41,6 @@ alias tt="tree"
 
 #alias ptc="source /opt/anaconda/bin/activate spyder-env"
 
-alias gc="git checkout"
-alias gb="git branch"
-alias ga="git add"
-alias gs="git status"
-alias gr="git restore"
-alias grm="git rm"
-alias gcm="git commit"
-
 alias cat="bat"
 alias antonio="make"
 alias tutorias="man"
@@ -64,7 +56,6 @@ alias dcsh="~/discord.sh &"
 alias dc="discord &"
 alias update="yay -Syu"
 alias uninstall="yay -Rncs"
-alias vim="nvim"
 
 eval $(thefuck --alias)
 

--- a/pkglist-common
+++ b/pkglist-common
@@ -1,7 +1,7 @@
 adobe-source-han-sans-otc-fonts
 amd-ucode
 android-tools
-antigen
+antigen-git
 atom
 autoconf
 automake
@@ -98,6 +98,7 @@ mutter
 nautilus
 neofetch
 neovim
+neovim-symlinks
 networkmanager
 noto-fonts
 noto-fonts-cjk

--- a/pkglist-laptop
+++ b/pkglist-laptop
@@ -1,6 +1,7 @@
 adobe-source-han-sans-otc-fonts
 android-tools
 android-udev
+antigen-git
 atom
 audacity
 autoconf
@@ -136,6 +137,7 @@ mutter
 nautilus
 neofetch
 neovim
+neovim-symlinks
 networkmanager
 notion-app
 noto-fonts


### PR DESCRIPTION
### Antigen

Since you're installing `antigen` (updated now to [`antigen-git`](https://aur.archlinux.org/packages/antigen-git/)), you can use the file provided by the package and remove the one sitting in your `$HOME`.

### Git aliases

You're already importing `git` with Antigen, which creates all these aliases for you: https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git. The difference between your aliases and the ones proposed are:

- `gc` changes to `git commit -v`
- `gcm` changes to `gcm='git checkout $(git_main_branch)'`
- `gco` is your new `git checkout`
- `gs` no longer ghosts Ghostscript
- `gst` is your new `git status`
- `gr` changes to `git remote`
- `grs` is your new `git restore`

### Neovim

If you install [`neovim-symlinks`](https://aur.archlinux.org/packages/neovim-symlinks/) you don't need to keep aliases for `nvim`. The package also provided some extra funcionality for diffs. 